### PR TITLE
Add support for Svelte files

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -63,7 +63,8 @@ function showOutput(msg) {
 function activate(context) {
 	const supportedDocuments = [
 		{ language: 'html', scheme: 'file' },
-		{ language: 'jade', scheme: 'file' }
+		{ language: 'jade', scheme: 'file' },
+		{ language: 'svelte', scheme: 'file' }
 	];
 
 	const command = vscode.commands.registerTextEditorCommand('attrsSorter.execute', (textEditor) => {


### PR DESCRIPTION
I would like to add support for Svelte files. The following patch has been working well for me for the past few days. The only additional requirements are to enable `recognizeSelfClosing` in PostHTML Parser, `svelteStrictMode` in Prettier, and to avoid certain syntax shortcuts.